### PR TITLE
-FIX: Wrong url for Interface documentation repo

### DIFF
--- a/01-introduction/index.adoc
+++ b/01-introduction/index.adoc
@@ -23,7 +23,7 @@ This chapter does not include any sourcecodes
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/02-create-developer-account/index.adoc
+++ b/02-create-developer-account/index.adoc
@@ -40,7 +40,7 @@ This chapter does not include any sourcecodes
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/03-create-application/index.adoc
+++ b/03-create-application/index.adoc
@@ -63,7 +63,7 @@ This chapter does not include any sourcecodes
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/04-create-maven-project/index.adoc
+++ b/04-create-maven-project/index.adoc
@@ -31,7 +31,7 @@ The SourceCodes can be found link:./src/[here].
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/05-onboard-appinstances/index.adoc
+++ b/05-onboard-appinstances/index.adoc
@@ -76,7 +76,7 @@ For onboarding tests, you can also use the link:https://github.com/DKE-Data/agri
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/06-message-exchange/index.adoc
+++ b/06-message-exchange/index.adoc
@@ -24,7 +24,7 @@ There are no source codes available for this chapter.
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/07-send-capabilities/index.adoc
+++ b/07-send-capabilities/index.adoc
@@ -27,7 +27,7 @@ The source code can be found link:./src[here].
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/08-routings/index.adoc
+++ b/08-routings/index.adoc
@@ -23,7 +23,7 @@ This chapter does not include any sourcecodes
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/09-request-endpointlist/index.adoc
+++ b/09-request-endpointlist/index.adoc
@@ -24,7 +24,7 @@ The sourcecode can be found link:./src[here].
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/10-send-file/index.adoc
+++ b/10-send-file/index.adoc
@@ -22,7 +22,7 @@ The source codes to this chapter can be found link:./src[here].
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/11-receive-file/index.adoc
+++ b/11-receive-file/index.adoc
@@ -24,7 +24,7 @@ The source codes can be found link:./src/[here].
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ Each chapter includes a Video for the description, some text or links to section
 
 
 == Related Topics
-- link:https://github.com//DKE-Data/agrirouter-api-documentation[API Documentation]
+- link:https://github.com//DKE-Data/agrirouter-interface-documentation[Interface Documentation]
 - link:https://github.com//DKE-Data/agrirouter-api-java[JAVA API]
 - link:https://github.com/DKE-Data/agrirouter-postman-tools[Postman Tools]
 - link:https://my-agrirouter.com[Agrirouter Website]


### PR DESCRIPTION
Since there is no "API Documentation" repository I suppose the [agrirouter-interface-documentation](https://github.com/DKE-Data/agrirouter-interface-documentation) was meant here.